### PR TITLE
Fix for SPLT skipping some UDP packets

### DIFF
--- a/src/flow.c
+++ b/src/flow.c
@@ -458,7 +458,7 @@ static void FlowEncryptedTrafficUpdate(Flow *f, Packet *p)
     else
         splt->sapp_bytes = p->payload_len;
 
-    if (f->flow_state == FLOW_STATE_ESTABLISHED) {
+    if (f->flow_state == FLOW_STATE_ESTABLISHED || (f->flow_state == FLOW_STATE_NEW && f->proto == IPPROTO_UDP)) {
 
         if (splt->splt_count < FLOW_SPLT_MAX_COUNT) {
             /* Update sequence of packet length & time (SPLT) */


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x ] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
Checks if a flow is UDP, and if so, allows for incomplete flows to be added to the SPLT. A flow is marked as complete once a packet has been sent in both directions, however this does not happen immediately for UDP communications. This leads to packets being skipped at the beginning of the flow.
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
